### PR TITLE
feat: Add custom logging and CORS middleware

### DIFF
--- a/Backend/src/__init__.py
+++ b/Backend/src/__init__.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from src.db.main import init_db
 from contextlib import asynccontextmanager
 from src.auth.routes import auth_router 
+from .middleware import register_middleware
 
 @asynccontextmanager
 async def life_span(app: FastAPI):
@@ -18,5 +19,7 @@ app = FastAPI(
     version=version,
     lifespan=life_span
 )
+
+register_middleware(app)
 
 app.include_router(auth_router, prefix=f"/api/{version}/auth", tags=["auth"])

--- a/Backend/src/middleware.py
+++ b/Backend/src/middleware.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from fastapi.requests import Request
+from fastapi.middleware.cors import CORSMiddleware
+import logging
+import time
+
+logger = logging.getLogger('uvicorn.access')
+logger.disabled = True
+
+def register_middleware(app: FastAPI):
+    
+
+    @app.middleware("http")
+    async def custom_logging(request: Request, call_next):
+        start_time = time.time()
+
+        response = await call_next(request)
+        processing_time = time.time() - start_time
+
+        message = f"{request.client.host}: {request.client.port} - {request.method} - {request.url.path} - {response.status_code} completed after {processing_time}s"
+
+        print(message)
+
+        return response 
+    
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+        allow_credentials=True,
+    )


### PR DESCRIPTION
This PR introduces a custom logging middleware to the Backend providing clear and consistent logging for every incoming HTTP request. This helps with debugging and monitoring the API's performance and status.

Additionally, it adds the CORSMiddleware to enable Cross-Origin Resource Sharing for the frontend application at http://localhost:5173 and http://127.0.0.1:5173. This allows the frontend to safely make API calls to the backend.

The logging from Uvicorn's access logger has been disabled to prevent duplicate log entries, ensuring a cleaner output.